### PR TITLE
fixed that the swagger path does not start with '/'.

### DIFF
--- a/swagger2-postman-generator.js
+++ b/swagger2-postman-generator.js
@@ -15,7 +15,9 @@ function populateRequestJsonIfDefined (postmanRequest, swaggerSpec, swaggerRefsL
 
     var relativePath = url.replace(`{{scheme}}://{{host}}:{{port}}${basePath}`, "")
     var swaggerPath = ((relativePath.replace(/\/:([a-zA-Z0-9]+)/, "/{$1}")).split("?"))[0]
-
+    if(swaggerPath[0] != '/') {
+        swaggerPath = '/' + swaggerPath;
+    }
     var swaggerPathRoot = swaggerSpec.paths[swaggerPath];
 
     if (!swaggerPathRoot) {


### PR DESCRIPTION
I have encountered the problem that the body of a request is not mapped when converting a swagger document to a postman collection.
The cause of the problem was that the swagger's path did not start with a '/'.
So, if the beginning of the swagger's path is not '/', the string '/' is added.